### PR TITLE
Add start with application option

### DIFF
--- a/frontend/src/pages/server/Administration.tsx
+++ b/frontend/src/pages/server/Administration.tsx
@@ -185,6 +185,12 @@ function ServerStartupCard({setServ, serv}: {setServ: React.Dispatch<React.SetSt
                                   convertValues: p.convertValues
                               }))}/><br/>
                     {/*<Checkbox label="Restart server on server quit" checked={serv?.restartOnServerQuit} onChange={(e) => setServ((p) => ({ ...p, restartOnServerQuit: e.target.checked }))} />*/}
+                    <Checkbox label="Start server when application opens" checked={serv?.startWithApplication}
+                              onChange={(e) => setServ((p) => ({
+                                  ...p,
+                                  startWithApplication: e.target.checked,
+                                  convertValues: p.convertValues
+                                }))}/><br/>
 
                     <FormLabel>Custom server "dash" arguments (only use args like: -EnableIdlePlayerKick
                         -ForceAllowCaveFlyers)</FormLabel>

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -2,15 +2,16 @@ package server
 
 import (
 	"fmt"
-	"github.com/JensvandeWiel/ArkAscendedServerManager/helpers"
-	"github.com/go-ini/ini"
-	"github.com/sethvargo/go-password/password"
-	"github.com/wailsapp/wails/v2/pkg/runtime"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/JensvandeWiel/ArkAscendedServerManager/helpers"
+	"github.com/go-ini/ini"
+	"github.com/sethvargo/go-password/password"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 var iniOpts = ini.LoadOptions{
@@ -77,6 +78,8 @@ func generateNewDefaultServer(id int) Server {
 
 		ServerMap:  "TheIsland_WP",
 		MaxPlayers: 70,
+
+		StartWithApplication: false,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -67,6 +67,8 @@ type Server struct {
 
 	ServerMap  string `json:"serverMap"`
 	MaxPlayers int    `json:"maxPlayers"`
+
+	StartWithApplication bool `json:"startWithApplication"`
 }
 
 // UpdateConfig updates the configuration files for the server e.g.: GameUserSettings.ini
@@ -96,6 +98,7 @@ func (s *Server) UpdateConfig() error {
 
 //TODO Add configuration parsing/loading/saving for server specific files
 //TODO Add startup arguments parsing
+//TODO Add check for running application (ensures no accidental duplicated servers, especially with addition of start with application)
 
 func (s *Server) Start() error {
 

--- a/server/server_controller.go
+++ b/server/server_controller.go
@@ -55,6 +55,25 @@ func (c *ServerController) Startup(ctx context.Context) {
 	}
 
 	c.serverDir = serverDir
+
+	c.StartServersWithApplication()
+}
+
+func (c *ServerController) StartServersWithApplication() {
+	servers, err := c.getAllServers()
+	if err != nil {
+		newErr := fmt.Errorf("Error getting all servers " + err.Error())
+		runtime.LogErrorf(c.ctx, newErr.Error())
+		return
+	}
+
+	for id := range servers {
+		server := c.Servers[id]
+		runtime.LogInfof(c.ctx, "StartWithApplication: %t", server.StartWithApplication)
+		if server.StartWithApplication {
+			c.StartServer(server.Id)
+		}
+	}
 }
 
 //endregion


### PR DESCRIPTION
This option enables servers to start when the application is launched which is useful if a host machine powers down (for any reason).

Startup seems like the best place to run it, let me know if there's a better place for it.

Closes #117 