### PR TITLE
Accurately display stats in the server list

### DIFF
--- a/frontend/src/components/ServerList.tsx
+++ b/frontend/src/components/ServerList.tsx
@@ -118,7 +118,7 @@ export const ServerList = ({ serverListType, servers, setActiveServer, setDrawer
                                         <div className={'text-xl font-bold break-all'}>{server.serverAlias ? server.serverAlias : "Unnamed Server"}</div>
                                         <div className={'text-lg mb-2'}>{server.ipAddress}:{server.queryPort}</div>
                                         
-                                        <div>Players: {playerCount !== undefined ? playerCount : 'Loading...'}</div>
+                                        <div>Players: {playerCount !== undefined ? playerCount : 'Loading...'}/{server.maxPlayers}</div>
                                         <div>Status: {serverStatus !== undefined ? (serverStatus ? 'Running' : 'Stopped') : 'Loading...'}</div>
                                         </div>
                                     </Card>

--- a/frontend/src/components/ServerList.tsx
+++ b/frontend/src/components/ServerList.tsx
@@ -1,70 +1,134 @@
 import { Button, Card, List, ListItem, ListItemButton } from "@mui/joy";
 import { server } from "../../wailsjs/go/models";
-import { LogError } from "../../wailsjs/runtime";
 import { IconPlus } from "@tabler/icons-react";
+import { GetConnectedPlayerCount, GetServerStatus } from "../../wailsjs/go/server/ServerController";
+import React, { useState, useEffect } from 'react';
+import {useAlert} from "../components/AlertProvider";
 
 enum ServerListType {
-  CARD,
-  LIST,
+    CARD,
+    LIST,
 }
 
 type Props = {
-  serverListType: ServerListType;
-  servers: {[key: number]: server.Server}|null;
-  setActiveServer: React.Dispatch<React.SetStateAction<number | undefined>>;
-  setDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  handleCreateNewServerClicked: () => void;
+    serverListType: ServerListType;
+    servers: {[key: number]: server.Server}|null;
+    setActiveServer: React.Dispatch<React.SetStateAction<number | undefined>>;
+    setDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    handleCreateNewServerClicked: () => void;
 }
 
+export const ServerList = ({ serverListType, servers, setActiveServer, setDrawerOpen, handleCreateNewServerClicked }: Props) => {
+    const [playerCounts, setPlayerCounts] = useState<Record<number, number | undefined>>({});
+    const [serverStatuses, setServerStatuses] = useState<Record<number, boolean | undefined>>({});
 
-export const ServerList = ({serverListType, servers, setActiveServer, setDrawerOpen, handleCreateNewServerClicked}:Props) => {
-  return (
-    <>
-        <List className={'flex flex-row flex-wrap items-start'}>
-        {
-            (servers === null) ? (
-                <ListItem>
-                    No servers found or failed to find servers
-                </ListItem>
+    const {addAlert} = useAlert()
+
+    // Having a separate useEffect for player counts and server statuses means that each value doesn't have to wait for the other
+    // I found that having them joined created a situation where player count would be loading as the server started, which forced
+    // the server status to wait for player count to be fetched.
+    useEffect(() => {
+        const refreshPlayerCounts = async () => {
+            if (servers) {
+                await Promise.all(
+                    Object.keys(servers).map(async (key) => {
+                        const serverId = parseInt(key, 10);
+                        if (!isNaN(serverId)) {
+                            GetConnectedPlayerCount(serverId).then((count) => {
+                                setPlayerCounts((prevPlayerCounts) => {
+                                    return {
+                                        ...prevPlayerCounts,
+                                        [serverId]: count as number
+                                    };
+                                });
+                            }).catch(() => {
+                                setPlayerCounts((prevPlayerCounts) => {
+                                    return {
+                                    ...prevPlayerCounts,
+                                    [serverId]: 0
+                                    };
+                                });
+                            })
+                        } else {
+                            console.error("Parsing server key failed");
+                        }
+                    })
+                );
+            }
+        };
+
+        refreshPlayerCounts();
+    }, [servers]);
+
+    useEffect(() => {
+        const refreshServerStatuses = async () => {
+            if (servers) {
+                await Promise.all(
+                    Object.keys(servers).map(async (key) => {
+                        const serverId = parseInt(key, 10);
+                        if (!isNaN(serverId)) {
+                            GetServerStatus(serverId).catch((reason) => {console.error("serverstatus: " + reason); addAlert(reason, "danger")}).then((count) => {
+                                setServerStatuses((prevServerStatuses) => {
+                                    return {
+                                        ...prevServerStatuses,
+                                        [serverId]: count as boolean | undefined
+                                    };
+                                });
+                            });
+                        } else {
+                            console.error("Parsing server key failed");
+                        }
+                    })
+                );
+            }
+        };
+
+        refreshServerStatuses();
+    }, [servers]);
+
+    return (
+        <>
+            <List className={'flex flex-row flex-wrap items-start'}>
+            {servers === null ? (
+                <ListItem>No servers found or failed to find servers</ListItem>
             ) : (
-                Object.keys(servers).map((key) => {
-                    const index = parseInt(key, 10); // The second argument is the base (radix), 10 for base 10 (decimal)
-
-                    if (isNaN(index)) {
-                        LogError("Parsing server key failed")
-                    }
-
-                    const server = servers[index]; // Parse the key to a number
-                    if(serverListType === ServerListType.LIST){
-                        return (
-                            <ListItem key={index}>
-                                <ListItemButton onClick={() => {setActiveServer(index); setDrawerOpen(false)}}>
-                                    {index}: {server.serverAlias? server.serverAlias : "Unnamed Server"}
-                                </ListItemButton>
-                            </ListItem>
-                        );
-                    }
-                    else if(serverListType === ServerListType.CARD){
-                        console.log(server)
-                        return (
-                            <ListItem className={'w-[calc(100%_*_(1/4))] p-[10px]'} key={index}>
-                                <Card className={'cursor-pointer w-full'} onClick={() => {setActiveServer(index)}}>
-                                    <div className={'px-2'}>
-                                        <div className={'text-xl font-bold break-all'}>{server.serverAlias? server.serverAlias : "Unnamed Server"}</div>
+                    Object.keys(servers).map((key) => {
+                        const index = parseInt(key, 10);
+                        if (isNaN(index)) {
+                            console.error("Parsing server key failed");
+                            return null;
+                        }
+                
+                        const server = servers[index];
+                        const playerCount = playerCounts[index];
+                        const serverStatus = serverStatuses[index];
+                        if (serverListType === ServerListType.LIST) {
+                            return (
+                                <ListItem key={index}>
+                                    <ListItemButton onClick={() => { setActiveServer(index); setDrawerOpen(false) }}>
+                                        {index}: {server.serverAlias ? server.serverAlias : "Unnamed Server"}
+                                    </ListItemButton>
+                                </ListItem>
+                            );
+                        } else if (serverListType === ServerListType.CARD) {
+                            return (
+                                <ListItem className={'w-[calc(100%_*_(1/4))] p-[10px]'} key={index}>
+                                    <Card className={'cursor-pointer w-full'} onClick={() => { setActiveServer(index) }}>
+                                        <div className={'px-2'}>
+                                        <div className={'text-xl font-bold break-all'}>{server.serverAlias ? server.serverAlias : "Unnamed Server"}</div>
                                         <div className={'text-lg mb-2'}>{server.ipAddress}:{server.queryPort}</div>
-
-                                        <div>Players: 0/40</div> {/* this still needs to be implemented! */}
-                                        <div>Status: Running</div> {/* this still needs to be implemented! */}
-                                    </div>
-                                </Card>
-                            </ListItem>
-                        );
-                    }
-                })
-            )
-        }
-        </List>
-        {serverListType === ServerListType.CARD ? <Button className={'ml-[10px]'} onClick={() => handleCreateNewServerClicked()}><IconPlus/> Create new server</Button> : <></>}
-    </>
-)
+                                        
+                                        <div>Players: {playerCount !== undefined ? playerCount : 'Loading...'}</div>
+                                        <div>Status: {serverStatus !== undefined ? (serverStatus ? 'Running' : 'Stopped') : 'Loading...'}</div>
+                                        </div>
+                                    </Card>
+                                </ListItem>
+                            );
+                        }
+                    })
+                )}
+            </List>
+                {serverListType === ServerListType.CARD ? <Button className={'ml-[10px]'} onClick={() => handleCreateNewServerClicked()}><IconPlus /> Create new server</Button> : <></>}
+            </>
+        );
 };

--- a/frontend/src/components/ServerList.tsx
+++ b/frontend/src/components/ServerList.tsx
@@ -1,134 +1,159 @@
 import { Button, Card, List, ListItem, ListItemButton } from "@mui/joy";
 import { server } from "../../wailsjs/go/models";
 import { IconPlus } from "@tabler/icons-react";
-import { GetConnectedPlayerCount, GetServerStatus } from "../../wailsjs/go/server/ServerController";
-import React, { useState, useEffect } from 'react';
-import {useAlert} from "../components/AlertProvider";
+import {
+  GetConnectedPlayerCount,
+  GetServerStatus,
+} from "../../wailsjs/go/server/ServerController";
+import React, { useState, useEffect } from "react";
+import { useAlert } from "../components/AlertProvider";
 
 enum ServerListType {
-    CARD,
-    LIST,
+  CARD,
+  LIST,
 }
 
 type Props = {
-    serverListType: ServerListType;
-    servers: {[key: number]: server.Server}|null;
-    setActiveServer: React.Dispatch<React.SetStateAction<number | undefined>>;
-    setDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    handleCreateNewServerClicked: () => void;
-}
+  serverListType: ServerListType;
+  servers: { [key: number]: server.Server } | null;
+  setActiveServer: React.Dispatch<React.SetStateAction<number | undefined>>;
+  setDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  handleCreateNewServerClicked: () => void;
+};
 
-export const ServerList = ({ serverListType, servers, setActiveServer, setDrawerOpen, handleCreateNewServerClicked }: Props) => {
-    const [playerCounts, setPlayerCounts] = useState<Record<number, number | undefined>>({});
-    const [serverStatuses, setServerStatuses] = useState<Record<number, boolean | undefined>>({});
+export const ServerList = ({serverListType, servers, setActiveServer, setDrawerOpen, handleCreateNewServerClicked}: Props) => {
+  const [playerCounts, setPlayerCounts] = useState<Record<number, number | undefined>>({});
+  const [serverStatuses, setServerStatuses] = useState<Record<number, boolean | undefined>>({});
 
-    const {addAlert} = useAlert()
+  const { addAlert } = useAlert();
 
-    // Having a separate useEffect for player counts and server statuses means that each value doesn't have to wait for the other
-    // I found that having them joined created a situation where player count would be loading as the server started, which forced
-    // the server status to wait for player count to be fetched.
-    useEffect(() => {
-        const refreshPlayerCounts = async () => {
-            if (servers) {
-                await Promise.all(
-                    Object.keys(servers).map(async (key) => {
-                        const serverId = parseInt(key, 10);
-                        if (!isNaN(serverId)) {
-                            GetConnectedPlayerCount(serverId).then((count) => {
-                                setPlayerCounts((prevPlayerCounts) => {
-                                    return {
-                                        ...prevPlayerCounts,
-                                        [serverId]: count as number
-                                    };
-                                });
-                            }).catch(() => {
-                                setPlayerCounts((prevPlayerCounts) => {
-                                    return {
-                                    ...prevPlayerCounts,
-                                    [serverId]: 0
-                                    };
-                                });
-                            })
-                        } else {
-                            console.error("Parsing server key failed");
-                        }
-                    })
-                );
+  // Having a separate useEffect for player counts and server statuses means that each value doesn't have to wait for the other
+  // I found that having them joined created a situation where player count would be loading as the server started, which forced
+  // the server status to wait for player count to be fetched.
+  useEffect(() => {
+    const refreshPlayerCounts = async () => {
+      if (!servers) {
+        return
+      }
+
+      await Promise.all(
+        Object.keys(servers).map(async (key) => {
+          const serverId = parseInt(key, 10);
+          if (isNaN(serverId)) {
+            console.error("Parsing server key failed");
+            return;
+          }
+
+          GetConnectedPlayerCount(serverId).then((count) => {
+            setPlayerCounts((prevPlayerCounts) => {
+              return {
+                ...prevPlayerCounts,
+                [serverId]: count as number,
+              };
+            });
+          }).catch(() => {
+            setPlayerCounts((prevPlayerCounts) => {
+              return {
+                ...prevPlayerCounts,
+                [serverId]: 0,
+              };
+            });
+          });
+        })
+      );
+    };
+
+    refreshPlayerCounts();
+  }, [servers]);
+
+  useEffect(() => {
+    const refreshServerStatuses = async () => {
+      if (!servers) {
+        return
+      }
+
+      await Promise.all(
+        Object.keys(servers).map(async (key) => {
+          const serverId = parseInt(key, 10);
+          if (isNaN(serverId)) {
+            console.error("Parsing server key failed");
+            return;
+          }
+
+          GetServerStatus(serverId).catch((reason) => {
+            console.error("serverstatus: " + reason);
+            addAlert(reason, "danger");
+          }).then((count) => {
+            setServerStatuses((prevServerStatuses) => {
+              return {
+                ...prevServerStatuses,
+                [serverId]: count as boolean | undefined,
+              };
+            });
+          });
+        })
+      );
+    };
+
+    refreshServerStatuses();
+  }, [servers]);
+
+  return (
+    <>
+      <List className={"flex flex-row flex-wrap items-start"}>
+        {servers === null ? (
+          <ListItem>No servers found or failed to find servers</ListItem>
+        ) : (
+          Object.keys(servers).map((key) => {
+            const index = parseInt(key, 10);
+            if (isNaN(index)) {
+              console.error("Parsing server key failed");
+              return null;
             }
-        };
 
-        refreshPlayerCounts();
-    }, [servers]);
+            const server = servers[index];
+            const playerCount = playerCounts[index];
+            const serverStatus = serverStatuses[index];
 
-    useEffect(() => {
-        const refreshServerStatuses = async () => {
-            if (servers) {
-                await Promise.all(
-                    Object.keys(servers).map(async (key) => {
-                        const serverId = parseInt(key, 10);
-                        if (!isNaN(serverId)) {
-                            GetServerStatus(serverId).catch((reason) => {console.error("serverstatus: " + reason); addAlert(reason, "danger")}).then((count) => {
-                                setServerStatuses((prevServerStatuses) => {
-                                    return {
-                                        ...prevServerStatuses,
-                                        [serverId]: count as boolean | undefined
-                                    };
-                                });
-                            });
-                        } else {
-                            console.error("Parsing server key failed");
-                        }
-                    })
-                );
+            if (serverListType === ServerListType.LIST) {
+              return (
+                <ListItem key={index}>
+                  <ListItemButton onClick={() => {
+                      setActiveServer(index);
+                      setDrawerOpen(false);
+                    }}
+                  >
+                    {index}:{" "}
+                    {server.serverAlias ? server.serverAlias : "Unnamed Server"}
+                  </ListItemButton>
+                </ListItem>
+              );
+            } else if (serverListType === ServerListType.CARD) {
+              return (
+                <ListItem className={"w-[calc(100%_*_(1/4))] p-[10px]"} key={index}>
+                  <Card className={"cursor-pointer w-full"} onClick={() => {setActiveServer(index);}}>
+                    <div className={"px-2"}>
+                      <div className={"text-xl font-bold break-all"}>{server.serverAlias ? server.serverAlias : "Unnamed Server"}</div>
+                      <div className={"text-lg mb-2"}>{server.ipAddress}:{server.queryPort}</div>
+
+                      <div>Players: {playerCount !== undefined ? `${playerCount}/${server.maxPlayers}` : "Loading..."}</div>
+                      <div>Status: {serverStatus !== undefined ? (serverStatus ? "Running" : "Stopped") : "Loading..."}
+                      </div>
+                    </div>
+                  </Card>
+                </ListItem>
+              );
             }
-        };
-
-        refreshServerStatuses();
-    }, [servers]);
-
-    return (
-        <>
-            <List className={'flex flex-row flex-wrap items-start'}>
-            {servers === null ? (
-                <ListItem>No servers found or failed to find servers</ListItem>
-            ) : (
-                    Object.keys(servers).map((key) => {
-                        const index = parseInt(key, 10);
-                        if (isNaN(index)) {
-                            console.error("Parsing server key failed");
-                            return null;
-                        }
-                
-                        const server = servers[index];
-                        const playerCount = playerCounts[index];
-                        const serverStatus = serverStatuses[index];
-                        if (serverListType === ServerListType.LIST) {
-                            return (
-                                <ListItem key={index}>
-                                    <ListItemButton onClick={() => { setActiveServer(index); setDrawerOpen(false) }}>
-                                        {index}: {server.serverAlias ? server.serverAlias : "Unnamed Server"}
-                                    </ListItemButton>
-                                </ListItem>
-                            );
-                        } else if (serverListType === ServerListType.CARD) {
-                            return (
-                                <ListItem className={'w-[calc(100%_*_(1/4))] p-[10px]'} key={index}>
-                                    <Card className={'cursor-pointer w-full'} onClick={() => { setActiveServer(index) }}>
-                                        <div className={'px-2'}>
-                                        <div className={'text-xl font-bold break-all'}>{server.serverAlias ? server.serverAlias : "Unnamed Server"}</div>
-                                        <div className={'text-lg mb-2'}>{server.ipAddress}:{server.queryPort}</div>
-                                        
-                                        <div>Players: {playerCount !== undefined ? playerCount : 'Loading...'}/{server.maxPlayers}</div>
-                                        <div>Status: {serverStatus !== undefined ? (serverStatus ? 'Running' : 'Stopped') : 'Loading...'}</div>
-                                        </div>
-                                    </Card>
-                                </ListItem>
-                            );
-                        }
-                    })
-                )}
-            </List>
-                {serverListType === ServerListType.CARD ? <Button className={'ml-[10px]'} onClick={() => handleCreateNewServerClicked()}><IconPlus /> Create new server</Button> : <></>}
-            </>
-        );
+          })
+        )}
+      </List>
+      {serverListType === ServerListType.CARD ? (
+        <Button className={"ml-[10px]"} onClick={() => handleCreateNewServerClicked()}>
+          <IconPlus /> Create new server
+        </Button>
+      ) : (
+        <></>
+      )}
+    </>
+  );
 };

--- a/server/server.go
+++ b/server/server.go
@@ -119,6 +119,7 @@ func (s *Server) Start() error {
 		if err != nil {
 			return fmt.Errorf("error starting server: %v", err)
 		}
+
 		runtime.EventsEmit(s.ctx, "onServerStart", s.Id)
 		if s.DiscordWebHookEnabled {
 			err := helpers.SendToDiscord(time.Now().Format(time.RFC822)+" ("+s.ServerAlias+") Server has started", s.DiscordWebHook)
@@ -270,4 +271,38 @@ func (s *Server) SaveWorld() error {
 		return err
 	}
 	return nil
+}
+
+func getPlayerCount(s Server) (int, error) {
+	players, err := s.helpers.SendRconCommand("listplayers", s.IpAddress, s.RCONPort, s.AdminPassword)
+	if err != nil {
+		return 0, err
+	}
+
+	if strings.HasPrefix(players, "No Players Connected") {
+		return 0, nil
+	}
+
+	// This returns the following format:
+	// 0. Username, ARK-Internal-ID
+	// So if more information is needed, it can be extracted
+	lines := strings.Split(players, "\n")
+	var nonEmptyLines []string
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			nonEmptyLines = append(nonEmptyLines, line)
+		}
+	}
+
+	return len(nonEmptyLines), nil
+}
+
+func (s *Server) GetServerPlayerCount() (int, error) {
+	playerCount, err := getPlayerCount(*s)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return playerCount, nil
 }

--- a/server/server_controller.go
+++ b/server/server_controller.go
@@ -92,6 +92,7 @@ func (c *ServerController) RunAutoSaveTimer() {
 
 	autoSave := time.NewTicker(time.Minute)
 	done := make(chan bool)
+	runtime.LogInfof(c.ctx, "Server Auto-Save Started")
 	go func() {
 		for {
 			select {
@@ -102,10 +103,6 @@ func (c *ServerController) RunAutoSaveTimer() {
 			}
 		}
 	}()
-
-	autoSave.Stop()
-	done <- true
-	runtime.LogInfof(c.ctx, "Auto-Save Stopped")
 }
 
 func (c *ServerController) AutoSaveServers() {
@@ -126,19 +123,21 @@ func (c *ServerController) AutoSaveServers() {
 
 	for id := range servers {
 		server := c.Servers[id]
-		if server.AutoSaveEnabled {
-			// if interval is multiple of iterations
-			if server.AutoSaveInterval <= 0 {
-				runtime.LogError(c.ctx, "Server auto-save interval set 0 or below")
-				continue
-			}
-			if c.autoSaveIterations%server.AutoSaveInterval == 0 {
-				runtime.LogInfo(c.ctx, "Running autosave for "+server.ServerName)
+		if server.IsServerRunning() {
+			if server.AutoSaveEnabled {
+				// if interval is multiple of iterations
+				if server.AutoSaveInterval <= 0 {
+					runtime.LogError(c.ctx, "Server auto-save interval set 0 or below")
+					continue
+				}
+				if c.autoSaveIterations%server.AutoSaveInterval == 0 {
+					runtime.LogInfo(c.ctx, "Running autosave for "+server.ServerName)
 
-				err = server.SaveWorld()
-				if err != nil {
-					newErr := fmt.Errorf("Server auto-save created an error: " + err.Error())
-					runtime.LogErrorf(c.ctx, newErr.Error())
+					err = server.SaveWorld()
+					if err != nil {
+						newErr := fmt.Errorf("Server auto-save created an error: " + err.Error())
+						runtime.LogErrorf(c.ctx, newErr.Error())
+					}
 				}
 			}
 		}
@@ -201,6 +200,24 @@ func (c *ServerController) GetServer(id int) (Server, error) {
 		return *server, newErr
 	}
 	return *server, nil
+}
+
+// GetConnectedPlayerCount returns the number of connected players
+func (c *ServerController) GetConnectedPlayerCount(id int) (int, error) {
+	server, err := c.GetServer(id)
+	if err != nil {
+		newErr := fmt.Errorf("Failed getting server: " + strconv.Itoa(id) + " with: " + err.Error())
+		runtime.LogError(c.ctx, newErr.Error())
+		return 0, newErr
+	}
+
+	resp, err := server.GetServerPlayerCount()
+	if err != nil {
+		// don't print the error, the server is probably just closed
+		return 0, err
+	}
+
+	return resp, nil
 }
 
 // CreateServer Creates a new server, returns it and adds it to the map. If it fails it returns an error which is catch-able in the Frontend.

--- a/server/server_controller.go
+++ b/server/server_controller.go
@@ -60,7 +60,6 @@ func (c *ServerController) Startup(ctx context.Context) {
 	c.serverDir = serverDir
 
 	c.StartServersWithApplication()
-	c.RunAutoSaveTimer()
 }
 
 // endregion
@@ -83,19 +82,20 @@ func (c *ServerController) StartServersWithApplication() {
 	}
 }
 
-// start repeating timer that calls auto-save
-// having one timer that manages all servers is advantageous:
-// - catches conditions where a user enables auto-save after the timer has started
-// - catches interval changes made after the timer has started
+// TODO Remove auto-save feature, it's built into ARK
 func (c *ServerController) RunAutoSaveTimer() {
 	c.autoSaveIterations = 0
 
 	autoSave := time.NewTicker(time.Minute)
 	done := make(chan bool)
+
 	runtime.LogInfof(c.ctx, "Server Auto-Save Started")
+
 	go func() {
 		for {
 			select {
+			case <-c.ctx.Done(): // Check if the context is canceled
+				return
 			case <-done:
 				return
 			case <-autoSave.C:
@@ -123,22 +123,21 @@ func (c *ServerController) AutoSaveServers() {
 
 	for id := range servers {
 		server := c.Servers[id]
-		if server.IsServerRunning() {
-			if server.AutoSaveEnabled {
-				// if interval is multiple of iterations
-				if server.AutoSaveInterval <= 0 {
-					runtime.LogError(c.ctx, "Server auto-save interval set 0 or below")
-					continue
-				}
-				if c.autoSaveIterations%server.AutoSaveInterval == 0 {
-					runtime.LogInfo(c.ctx, "Running autosave for "+server.ServerName)
+		if !server.IsServerRunning() || !server.AutoSaveEnabled {
+			continue
+		}
 
-					err = server.SaveWorld()
-					if err != nil {
-						newErr := fmt.Errorf("Server auto-save created an error: " + err.Error())
-						runtime.LogErrorf(c.ctx, newErr.Error())
-					}
-				}
+		// if interval is multiple of iterations
+		if server.AutoSaveInterval <= 0 {
+			runtime.LogError(c.ctx, "Server auto-save interval set 0 or below")
+			continue
+		}
+		if c.autoSaveIterations%server.AutoSaveInterval == 0 {
+			runtime.LogInfo(c.ctx, "Running autosave for "+server.ServerName)
+			err = server.SaveWorld()
+			if err != nil {
+				newErr := fmt.Errorf("Server auto-save created an error: " + err.Error())
+				runtime.LogErrorf(c.ctx, newErr.Error())
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds statistics to the ServerList page. It accurately reports the server status (Running/Stopped) and the player count (using a slightly cheaty method that relies on RCON for now). It seems that as of now, ARK:SA doesn't support direct server queries, and as such, we're not able to get proper information from the server. This way is perfectly valid for the time being though.

One limitation of this approach is that, with a large number of servers, (or even just a server that is off), all of the servers need to wait for the timeout before updating their values. This means that the player count can take ~5 seconds to update.