### PR TITLE
Duplicated INI entry fixes

### DIFF
--- a/server/game.go
+++ b/server/game.go
@@ -282,12 +282,13 @@ func (s *Server) SaveGameIni(filePathToLoadFrom string, overrideUseIniConfig boo
 
 	//modify ini file here
 
+	//Same as GUS change. changes from app should now reflect in actual INI file
+	gIni.Append([]byte(s.AdditionalGameSections))
+
 	err = gIni.ReflectFrom(&s.Game)
 	if err != nil {
 		return err
 	}
-
-	gIni.Append([]byte(s.AdditionalGameSections))
 
 	err = gIni.SaveTo(filepath.Join(s.ServerPath, "ShooterGame\\Saved\\Config\\WindowsServer\\Game.ini"))
 	if err != nil {

--- a/server/gus.go
+++ b/server/gus.go
@@ -57,7 +57,7 @@ type ServerSettings struct {
 	//ExtinctionEventTimeInterval                int   `json:"extinctionEventTimeInterval" ini:"ExtinctionEventTimeInterval"`           //TODO: Usage unknown in asa
 	FastDecayUnsnappedCoreStructures           bool    `json:"fastDecayUnsnappedCoreStructures" ini:"FastDecayUnsnappedCoreStructures"` //TODO: Usage unknown in asa
 	ForceAllStructureLocking                   bool    `json:"forceAllStructureLocking" ini:"ForceAllStructureLocking"`
-	GlobalVoiceChat                            bool    `json:"globalVoiceChat" ini:"globalVoiceChat"` //TODO if it actually starts with a non capital letter
+	GlobalVoiceChat                            bool    `json:"globalVoiceChat" ini:"GlobalVoiceChat"` //TODO if it actually starts with a non capital letter
 	HarvestAmountMultiplier                    float32 `json:"harvestAmountMultiplier" ini:"HarvestAmountMultiplier"`
 	HarvestHealthMultiplier                    float32 `json:"harvestHealthMultiplier" ini:"HarvestHealthMultiplier"`
 	IgnoreLimitMaxStructuresInRangeTypeFlag    bool    `json:"ignoreLimitMaxStructuresInRangeTypeFlag" ini:"IgnoreLimitMaxStructuresInRangeTypeFlag"` //TODO: Usage unknown in asa
@@ -96,7 +96,7 @@ type ServerSettings struct {
 	PreventOfflinePvPInterval                  float32 `json:"preventOfflinePvPInterval" ini:"PreventOfflinePvPInterval"`
 	PreventSpawnAnimations                     bool    `json:"preventSpawnAnimations" ini:"PreventSpawnAnimations"`
 	PreventTribeAlliances                      bool    `json:"preventTribeAlliances" ini:"PreventTribeAlliances"`
-	ProximityChat                              bool    `json:"proximityChat" ini:"proximityChat"`
+	ProximityChat                              bool    `json:"proximityChat" ini:"ProximityChat"`
 	PvEAllowStructuresAtSupplyDrops            bool    `json:"pveAllowStructuresAtSupplyDrops" ini:"PvEAllowStructuresAtSupplyDrops"`
 	PvEDinoDecayPeriodMultiplier               float32 `json:"pveDinoDecayPeriodMultiplier" ini:"PvEDinoDecayPeriodMultiplier"`
 	PvEStructureDecayPeriodMultiplier          float32 `json:"pveStructureDecayPeriodMultiplier" ini:"PvEStructureDecayPeriodMultiplier"`
@@ -113,7 +113,7 @@ type ServerSettings struct {
 	ServerCrosshair                            bool    `json:"serverCrosshair" ini:"ServerCrosshair"`
 	ServerForceNoHUD                           bool    `json:"serverForceNoHUD" ini:"ServerForceNoHUD"`
 	ServerHardcore                             bool    `json:"serverHardcore" ini:"ServerHardcore"`
-	ServerPVE                                  bool    `json:"serverPVE" ini:"serverPVE"`
+	ServerPVE                                  bool    `json:"serverPVE" ini:"ServerPVE"`
 	ShowFloatingDamageText                     bool    `json:"showFloatingDamageText" ini:"ShowFloatingDamageText"`
 	ShowMapPlayerLocation                      bool    `json:"showMapPlayerLocation" ini:"ShowMapPlayerLocation"`
 	StructureDamageMultiplier                  float32 `json:"structureDamageMultiplier" ini:"StructureDamageMultiplier"`
@@ -133,7 +133,7 @@ type ServerSettings struct {
 	//CrossARK Transfers
 	CrossARKAllowForeignDinoDownloads bool    `json:"crossARKAllowForeignDinoDownloads" ini:"CrossARKAllowForeignDinoDownloads"` //TODO: Usage unknown in asa
 	MinimumDinoReuploadInterval       float32 `json:"minimumDinoReuploadInterval" ini:"MinimumDinoReuploadInterval"`             //TODO: Usage unknown in asa
-	NoTributeDownloads                bool    `json:"noTributeDownloads" ini:"noTributeDownloads"`
+	NoTributeDownloads                bool    `json:"noTributeDownloads" ini:"NoTributeDownloads"`
 	PreventDownloadDinos              bool    `json:"preventDownloadDinos" ini:"PreventDownloadDinos"`
 	PreventDownloadItems              bool    `json:"preventDownloadItems" ini:"PreventDownloadItems"`
 	PreventDownloadSurvivors          bool    `json:"preventDownloadSurvivors" ini:"PreventDownloadSurvivors"`
@@ -444,23 +444,29 @@ func (s *Server) SaveGameUserSettingsIni(filePathToLoadFrom string, overrideUseI
 
 	s.GameUserSettings.ServerSettings.ActiveMods = s.Mods
 
+	// Append Additional Settings before reflect because gusIni.Append() reloads the original file without the changes
+	gusIni.Append([]byte(s.AdditionalGUSSections))
+
 	err = gusIni.ReflectFrom(&s.GameUserSettings)
 	if err != nil {
 		return err
 	}
 
-	if s.ServerPassword != "" {
-		gusIni.Section("ServerSettings").Key("ServerPassword").SetValue(s.ServerPassword)
-	}
-	if s.SpectatorPassword != "" {
-		gusIni.Section("ServerSettings").Key("SpectatorPassword").SetValue(s.SpectatorPassword)
-	}
+	// INI values for these wouldn't change
+	gusIni.Section("ServerSettings").Key("ServerPassword").SetValue(s.ServerPassword)
+	gusIni.Section("ServerSettings").Key("SpectatorPassword").SetValue(s.SpectatorPassword)
 
-	gusIni.Section("ServerSettings").Key("AdminPassword").SetValue(s.AdminPassword)
+	// if s.ServerPassword != "" {
+	// 	gusIni.Section("ServerSettings").Key("ServerPassword").SetValue(s.ServerPassword)
+	// }
+	// if s.SpectatorPassword != "" {
+	// 	gusIni.Section("ServerSettings").Key("SpectatorPassword").SetValue(s.SpectatorPassword)
+	// }
 
-	gusIni.Append([]byte(s.AdditionalGUSSections))
+	// Not Needed anymore since the value is reflected to the ini above
+	// gusIni.Section("ServerSettings").Key("AdminPassword").SetValue(s.AdminPassword)
 
-	err = gusIni.SaveTo(filepath.Join(s.ServerPath, "ShooterGame\\Saved\\Config\\WindowsServer\\GameUserSettings.ini"))
+	err = gusIni.SaveTo(filepath.Join(filePath))
 	if err != nil {
 		return err
 	}

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"github.com/StackExchange/wmi"
 	"io"
 	"io/ioutil"
 	"net"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/StackExchange/wmi"
+
 	"github.com/JensvandeWiel/ArkAscendedServerManager/helpers"
 	"github.com/go-ini/ini"
 	"github.com/sethvargo/go-password/password"
@@ -20,7 +21,9 @@ import (
 )
 
 var iniOpts = ini.LoadOptions{
-	AllowShadows: true,
+	// This setting allowed duplicate values in the INI files. With the Changes values should now be replaced
+	AllowShadows:            false,
+	PreserveSurroundedQuote: true,
 }
 
 func replaceForwardSlashInFile(filePath string) error {

--- a/server/server_controller.go
+++ b/server/server_controller.go
@@ -271,6 +271,12 @@ func (c *ServerController) SaveServerConfigFile(content string, id int) error {
 		return err
 	}
 
+	// Lets the program save the INI files when pressing Save Config from administration as well as Addition Setting Section
+	err = serv.UpdateConfig()
+	if err != nil {
+		return fmt.Errorf("error starting server: failed updating server configuration: %v", err)
+	}
+
 	return nil
 
 }


### PR DESCRIPTION
INI values no longer duplicate and are correctly represented on Server start when configs are updated. This should fix the issues people were having with RCON, it was working for me when I built it. 

For easier testing, I also added the Update config trigger when the save buttons are pressed when adding additional settings through text in the multipliers tab as well as when saving the config in the administration.